### PR TITLE
no-magic-numbers

### DIFF
--- a/configs/es/bestPractices.js
+++ b/configs/es/bestPractices.js
@@ -23,7 +23,7 @@ module.exports = {
     "no-labels": 2,
     "no-lone-blocks": 1,
     "no-loop-func": 2,
-    "no-magic-numbers": 1,
+    "no-magic-numbers": [1, {"ignoreArrayIndexes": true, "ignore": [-1, 0, 1]}],
     "no-multi-spaces": 1,
     "no-multi-str": 2,
     "no-native-reassign": 2,


### PR DESCRIPTION
Allow to use numbers as array indexes, and allow -1, 0, 1:

``` javascript
if (edges.length === 1)
myArray[3]
```
