### PR TITLE
Allow indentation for switch statements

### DIFF
--- a/configs/es/stylistic.js
+++ b/configs/es/stylistic.js
@@ -6,7 +6,7 @@ module.exports = {
     "computed-property-spacing": [2, "never"],
     "eol-last": 2,
     "func-names": 0,
-    "indent": [2, 2],
+    "indent": [2, 2, {"SwitchCase": 1}],
     "jsx-quotes": [1, "prefer-double"],
     // key-spacing: [2, {"beforeColon": false, "afterColon": true}],
     "keyword-spacing": 2,


### PR DESCRIPTION
I prefer indenting case statements, lik this:

``` javascript
switch (something) {
  case foo: break 
  case bar: break
  default:
    break
}
```

over this

``` javascript
switch (something) {
case foo: break
case bar: break
default:
  break
}
```
