### PR TITLE
Add support for property initializer syntax

### DIFF
--- a/configs/es/bestPractices.js
+++ b/configs/es/bestPractices.js
@@ -18,7 +18,7 @@ module.exports = {
     "no-fallthrough": 1,
     "no-implicit-globals": 2,
     "no-implied-eval": 2,
-    "no-invalid-this": 2,
+    "babel/no-invalid-this": 2,
     "no-iterator": 2,
     "no-labels": 2,
     "no-lone-blocks": 1,

--- a/configs/es/index.js
+++ b/configs/es/index.js
@@ -8,7 +8,7 @@ module.exports = {
     "skalar/configs/es/stylistic",
     "skalar/configs/es/es6",
   ],
-
+  "plugins": ["babel"],
   "root": true,
   "parser": "babel-eslint",
   "env": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/Skalar/eslint-config-skalar#readme",
   "dependencies": {
-    "babel-eslint": "^6.0.4"
+    "babel-eslint": "^6.0.4",
+    "eslint-plugin-babel": "^4.1.2"
   }
 }


### PR DESCRIPTION
This is an experimental feature:
  https://babeljs.io/docs/plugins/transform-class-properties/

However, example code from the react docs contains the following example:

```jsx
class LoggingButton extends React.Component {
  // This syntax ensures `this` is bound within handleClick.
  // Warning: this is *experimental* syntax.
  handleClick = () => {
    console.log('this is:', this);
  }

  render() {
    return (
      <button onClick={this.handleClick}>
        Click me
      </button>
    );
  }
}
```

Since our projects probably all use babel with support for property initializer
syntax, I think it makes sense to use an eslint rule that also supports them.

Maybe we do not want to support "experimental" features to avoid issues down the
road, but given that this is the "react way" we would end up changing this in
all our react projects anyway, so doing it here means less duplication across
projects. I added it to core config since this is not really a react specific
feature and is valid in any project using babel.